### PR TITLE
Emit an error if stderr is not empty

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -32,6 +32,11 @@ module.exports = (options = {}) ->
         @emit 'error', err
         return next()
 
+      if stderr.trim().length > 0
+        err = new gutil.PluginError PLUGIN_NAME, stderr
+        @emit 'error', err
+        return next()
+
       styleguideHtmlFilePath = "#{styleguideFilePath}.html"
       styleguideCssFilePath = "#{styleguideFilePath}.css"
 


### PR DESCRIPTION
Currently, `stderr` is being completely ignored.